### PR TITLE
Prevent crash when providing an invalid file on the command line

### DIFF
--- a/src/window.c
+++ b/src/window.c
@@ -329,7 +329,9 @@ gl_window_new_from_file (const gchar *filename)
 	label = gl_xml_label_open (abs_filename, &status);
 	g_free (abs_filename);
 
-	gl_window_set_label (window, label);
+	if (label) {
+		gl_window_set_label (window, label);
+	}
 
 	gl_debug (DEBUG_WINDOW, "END");
 


### PR DESCRIPTION
Very simple patch. I stumbled upon this when I mistyped and provided the wrong file on the command line.