### PR TITLE
Fixed the screenshot URL

### DIFF
--- a/data/appdata/glabels-3.appdata.xml.in
+++ b/data/appdata/glabels-3.appdata.xml.in
@@ -24,7 +24,7 @@
   </description>
   <screenshots>
     <screenshot height="640" width="881" type="default">
-      <image>http://glabels.org/screenshots/320-screenshot-main.png</image>
+      <image>http://glabels.org/images/320-screenshot-main.png</image>
     </screenshot>
   </screenshots>
   <url type="homepage">http://glabels.org/</url>


### PR DESCRIPTION
You forgot to adapt the link when changing https://github.com/jimevins/glabels.org or set a redirect.
