### PR TITLE
Added Avery 89100 family Binder Spine Inserts

### DIFF
--- a/templates/avery-us-templates.xml
+++ b/templates/avery-us-templates.xml
@@ -883,6 +883,45 @@
     </Label-rectangle>
   </Template>
 
+
+  <!-- =================================================================== -->
+  <!-- Avery 89100 family: Binder Spine Inserts                            -->
+  <!-- =================================================================== -->
+  <Template brand="Avery" part="89101" size="US-Letter" description="Binder Spine Inserts, for 0.5 inch binders">
+    <Label-rectangle id="0" width="0.5in" height="11in" round="0in" x_waste="0in" y_waste="0in">
+      <Markup-margin size="0.125in"/>
+      <Layout nx="16" ny="1" x0="0.25in" y0="0in" dx="0.5in" dy="11in"/>
+    </Label-rectangle>
+  </Template>
+  <Template brand="Avery" part="89102" size="US-Letter" description="Binder Spine Inserts, for 1 inch binders">
+    <Label-rectangle id="0" width="1in" height="11in" round="0in" x_waste="0in" y_waste="0in">
+      <Markup-margin size="0.125in"/>
+      <Layout nx="8" ny="1" x0="0.25in" y0="0in" dx="1in" dy="11in"/>
+    </Label-rectangle>
+  </Template>
+  <Template brand="Avery" part="89103" equiv="89102"/>
+  <Template brand="Avery" part="89303" equiv="89102"/>
+  <Template brand="Avery" part="89104" size="US-Letter" description="Binder Spine Inserts, for 1.5 inch binders">
+    <Label-rectangle id="0" width="1.5in" height="11in" round="0in" x_waste="0in" y_waste="0in">
+      <Markup-margin size="0.125in"/>
+      <Layout nx="5" ny="1" x0="0.5in" y0="0in" dx="1.5in" dy="11in"/>
+    </Label-rectangle>
+  </Template>
+  <Template brand="Avery" part="89305" equiv="89104"/>
+  <Template brand="Avery" part="89106" size="US-Letter" description="Binder Spine Inserts, for 2 inch binders">
+    <Label-rectangle id="0" width="2in" height="11in" round="0in" x_waste="0in" y_waste="0in">
+      <Markup-margin size="0.125in"/>
+      <Layout nx="4" ny="1" x0="0.25in" y0="0in" dx="2in" dy="11in"/>
+    </Label-rectangle>
+  </Template>
+  <Template brand="Avery" part="89307" equiv="89106"/>
+  <Template brand="Avery" part="89109" size="US-Letter" description="Binder Spine Inserts, for 3 inch binders">
+    <Label-rectangle id="0" width="2.5in" height="11in" round="0in" x_waste="0in" y_waste="0in">
+      <Markup-margin size="0.125in"/>
+      <Layout nx="3" ny="1" x0="0.5in" y0="0in" dx="2.5in" dy="11in"/>
+    </Label-rectangle>
+  </Template>
+
 </Glabels-templates>
 
 


### PR DESCRIPTION
These templates are for creating strips to be inserted into the spine pockets of binders.