### PR TITLE
Prevent crash when using combo search on “Select Product”

### DIFF
--- a/src/media-select.c
+++ b/src/media-select.c
@@ -786,14 +786,15 @@ gl_media_select_get_name (glMediaSelect *this)
                 g_assert_not_reached ();
         }
 
-        if (gtk_tree_selection_get_mode (selection) == GTK_SELECTION_NONE)
+        gboolean has_selection = gtk_tree_selection_get_selected (selection, &model, &iter);
+
+        if (has_selection == TRUE)
         {
-                name = NULL;
+                gtk_tree_model_get (model, &iter, NAME_COLUMN, &name, -1);
         }
         else
         {
-                gtk_tree_selection_get_selected (selection, &model, &iter);
-                gtk_tree_model_get (model, &iter, NAME_COLUMN, &name, -1);
+                name = NULL;
         }
 
         gl_debug (DEBUG_MEDIA_SELECT, "END");


### PR DESCRIPTION
_Re-submitting an earlier botched pull request._

Starting to type in the pre-defined labels combo boxes (e.g., File → New → Recent/Search all/Custom) would crash the program.

As per additional description:

```
GtkSelectionMode can also be GTK_SELECTION_BROWSE, which does not
guarantee that a selection is available. Checking the return value
of gtk_tree_selection_get_selected() seems to provides a clearer
picture.
```

I'm not really experienced with GTK, but this seems like a reasonably well working solution.

Testing done: After applying the patch, I can search in the list of pre-defined labels by starting to type. Clearing the search pop-up results in nothing to be selected, which causes the 'Next' button to be disabled, as expected.
