### PR TITLE
Fix out of bounds read when label is empty

### DIFF
--- a/src/text-node.c
+++ b/src/text-node.c
@@ -283,7 +283,7 @@ gl_text_node_lines_new_from_text (const gchar *text)
 			nodes = NULL;
 		}
 	}
-	if (*(p - 1) != '\n') {
+	if (p != text && *(p - 1) != '\n') {
 		lines = g_list_append (lines, nodes);
 	}
 


### PR DESCRIPTION
_This was detected with ASan (`-fsanitize=address`)._

If a text label was empty `*p` would be `0`, and `p` would point to the same address as `text` (as initialized in the for-loop), i.e. the beginning of the string; `*(p - 1)` would be out of bounds. A simple check to see if `p` is not at the beginning of `text` prevents this. (Alternatively `*p == 0 || …` — not sure which one is better or clearer)