### PR TITLE
Remove deprecated Application category from desktop file

### DIFF
--- a/data/desktop/glabels-3.0.desktop.in
+++ b/data/desktop/glabels-3.0.desktop.in
@@ -6,6 +6,6 @@ Exec=glabels-3 %F
 Icon=glabels-3.0
 Terminal=false
 Type=Application
-Categories=Application;Office;GTK;
+Categories=Office;GTK;
 StartupNotify=true
 MimeType=application/x-glabels;


### PR DESCRIPTION
```
$ desktop-file-validate glabels-3.0.desktop.in

glabels-3.0.desktop.in: warning: value "Application;Office;GTK;" for key "Categories" in group "Desktop Entry" contains a deprecated value "Application"
```
