### PR TITLE
Add missing collate flag if generating labels via glabels-3-batch

### DIFF
--- a/README
+++ b/README
@@ -51,3 +51,10 @@ Website
 
 http://glabels.org/
 
+
+Brozkeff's fork information
+===========================
+
+This fork adds --collate (-a) flag to the glabels-3-batch binary because it is missing in the upstream version and it does not allow using this flag when using glabels for automation in scripts. 
+
+Ubuntu 22.04 deb package compiled against older Debian's barcode library to keep EAN13 and other barcode support. May need to manually put the relevant libraries to /usr/local/lib, the package was not tested much on a default ubuntu install.

--- a/src/glabels-batch.c
+++ b/src/glabels-batch.c
@@ -44,6 +44,7 @@ static gint     n_sheets         = 1;
 static gint     first            = 1;
 static gboolean outline_flag     = FALSE;
 static gboolean reverse_flag     = FALSE;
+static gboolean collate_flag     = FALSE;
 static gboolean crop_marks_flag  = FALSE;
 static gchar    *input           = NULL;
 static gchar    **remaining_args = NULL;
@@ -60,6 +61,8 @@ static GOptionEntry option_entries[] = {
         {"outline", 'l', 0, G_OPTION_ARG_NONE, &outline_flag,
          N_("print outlines (to test printer alignment)"), NULL},
         {"reverse", 'r', 0, G_OPTION_ARG_NONE, &reverse_flag,
+         N_("print in reverse (i.e. a mirror image)"), NULL},
+        {"collate", 'a', 0, G_OPTION_ARG_NONE, &collate_flag,
          N_("print in reverse (i.e. a mirror image)"), NULL},
         {"cropmarks", 'C', 0, G_OPTION_ARG_NONE, &crop_marks_flag,
          N_("print crop marks"), NULL},
@@ -162,6 +165,7 @@ main (int argc, char **argv)
                         gl_print_op_set_first           (print_op, first);
                         gl_print_op_set_outline_flag    (print_op, outline_flag);
                         gl_print_op_set_reverse_flag    (print_op, reverse_flag);
+                        gl_print_op_set_collate_flag    (print_op, collate_flag);
                         gl_print_op_set_crop_marks_flag (print_op, crop_marks_flag);
                         if (merge)
                         {

--- a/src/glabels-batch.c
+++ b/src/glabels-batch.c
@@ -63,7 +63,7 @@ static GOptionEntry option_entries[] = {
         {"reverse", 'r', 0, G_OPTION_ARG_NONE, &reverse_flag,
          N_("print in reverse (i.e. a mirror image)"), NULL},
         {"collate", 'a', 0, G_OPTION_ARG_NONE, &collate_flag,
-         N_("print in reverse (i.e. a mirror image)"), NULL},
+         N_("collate if more copies are present (e.g. to print same label on one page)"), NULL},
         {"cropmarks", 'C', 0, G_OPTION_ARG_NONE, &crop_marks_flag,
          N_("print crop marks"), NULL},
         {"input", 'i', 0, G_OPTION_ARG_STRING, &input,


### PR DESCRIPTION
Currently it seems the glabels-3-batch is missing the option to toggle collate flag that can be set when using GUI. I frequently need to generate dozens of pages of labels from a CSV file and then separate individual pages in such a way that each page contains labels of exactly one type.
To use collation on a sheet of 4 labels so that one label is on one page, 4 copies and collation are needed: 
-c 4 -a 1 

New flag is --collate (-a), default 0, can be switched on.