### PR TITLE
Remove most uses of stdout for debug, etc. #49.

### DIFF
--- a/libglabels/lgl-db.c
+++ b/libglabels/lgl-db.c
@@ -744,15 +744,15 @@ lgl_db_print_known_papers (void)
                 lgl_db_init ();
         }
 
-        g_print ("%s():\n", __FUNCTION__);
+        fprintf (stderr, "%s():\n", __FUNCTION__);
         for (p = model->papers; p != NULL; p = p->next)
         {
                 paper = (lglPaper *) p->data;
 
-                g_print ("PAPER id=\"%s\", name=\"%s\", width=%gpts, height=%gpts\n",
+                fprintf (stderr, "PAPER id=\"%s\", name=\"%s\", width=%gpts, height=%gpts\n",
                          paper->id, paper->name, paper->width, paper->height);
         }
-        g_print ("\n");
+        fprintf (stderr, "\n");
 
 }
 
@@ -1143,14 +1143,14 @@ lgl_db_print_known_categories (void)
                 lgl_db_init ();
         }
 
-        g_print ("%s():\n", __FUNCTION__);
+        fprintf (stderr, "%s():\n", __FUNCTION__);
         for (p = model->categories; p != NULL; p = p->next)
         {
                 category = (lglCategory *) p->data;
 
-                g_print ("CATEGORY id=\"%s\", name=\"%s\"\n", category->id, category->name);
+                fprintf (stderr, "CATEGORY id=\"%s\", name=\"%s\"\n", category->id, category->name);
         }
-        g_print ("\n");
+        fprintf (stderr, "\n");
 
 }
 
@@ -1384,15 +1384,15 @@ lgl_db_print_known_vendors (void)
                 lgl_db_init ();
         }
 
-        g_print ("%s():\n", __FUNCTION__);
+        fprintf (stderr, "%s():\n", __FUNCTION__);
         for (p = model->vendors; p != NULL; p = p->next)
         {
                 vendor = (lglVendor *) p->data;
 
-                g_print ("VENDOR name=\"%s\", url=\"%s\"\n",
+                fprintf (stderr, "VENDOR name=\"%s\", url=\"%s\"\n",
                          vendor->name, vendor->url);
         }
-        g_print ("\n");
+        fprintf (stderr, "\n");
 
 }
 
@@ -2097,16 +2097,16 @@ lgl_db_print_known_templates (void)
                 lgl_db_init ();
         }
 
-        g_print ("%s():\n", __FUNCTION__);
+        fprintf (stderr, "%s():\n", __FUNCTION__);
         for (p=model->templates; p!=NULL; p=p->next)
         {
                 template = (lglTemplate *)p->data;
 
-                g_print("TEMPLATE brand=\"%s\", part=\"%s\", description=\"%s\"\n",
+                fprintf (stderr, "TEMPLATE brand=\"%s\", part=\"%s\", description=\"%s\"\n",
                         template->brand, template->part, template->description);
 
         }
-        g_print ("\n");
+        fprintf (stderr, "\n");
 
 }
 

--- a/libglabels/lgl-template.c
+++ b/libglabels/lgl-template.c
@@ -1414,15 +1414,15 @@ compare_origins (gconstpointer a,
 void
 lgl_template_print (const lglTemplate *template)
 {
-        g_print ("---- %s( TEMPLATE=%p ) ----\n", __FUNCTION__, template);
+        fprintf (stderr, "---- %s( TEMPLATE=%p ) ----\n", __FUNCTION__, template);
 
-        g_print("brand=\"%s\", part=\"%s\", description=\"%s\"\n",
+        fprintf (stderr, "brand=\"%s\", part=\"%s\", description=\"%s\"\n",
                 template->brand, template->part, template->description);
 
-        g_print("paper_id=\"%s\", page_width=%g, page_height=%g\n",
+        fprintf (stderr, "paper_id=\"%s\", page_width=%g, page_height=%g\n",
                 template->paper_id, template->page_width, template->page_height);
 
-        g_print ("\n");
+        fprintf (stderr, "\n");
 
 }
 

--- a/libglabels/lgl-template.c
+++ b/libglabels/lgl-template.c
@@ -28,6 +28,7 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <math.h>
+#include <stdio.h>
 
 #include "libglabels-private.h"
 

--- a/libglbarcode/lgl-barcode-onecode.c
+++ b/libglbarcode/lgl-barcode-onecode.c
@@ -30,6 +30,7 @@
 #include <glib.h>
 #include <ctype.h>
 #include <string.h>
+#include <stdio.h>
 
 /*========================================================*/
 /* Private macros and constants.                          */

--- a/libglbarcode/lgl-barcode-onecode.c
+++ b/libglbarcode/lgl-barcode-onecode.c
@@ -666,9 +666,9 @@ int104_print (Int104  *x)
 
         for ( i = 0; i < 13; i++ )
         {
-                g_print ("%02x ", x->byte[i] & 0xFF);
+                fprintf (stderr, "%02x ", x->byte[i] & 0xFF);
         }
-        g_print ("\n");
+        fprintf (stderr, "\n");
 }
 #endif
 

--- a/src/debug.c
+++ b/src/debug.c
@@ -122,7 +122,7 @@ gl_debug (glDebugSection  section,
 		msg = g_strdup_vprintf (format, args);
 		va_end (args);
 
-		g_print ("%s:%d (%s) %s\n", file, line, function, msg);
+		g_debug ("%s:%d (%s) %s\n", file, line, function, msg);
 
 		g_free (msg);
 	}

--- a/src/glabels-batch.c
+++ b/src/glabels-batch.c
@@ -104,7 +104,7 @@ main (int argc, char **argv)
         gtk_parse_args (&argc, &argv);
         if (!g_option_context_parse (option_context, &argc, &argv, &error))
 	{
-	        g_print(_("%s\nRun '%s --help' to see a full list of available command line options.\n"),
+	        fprintf (stderr, _("%s\nRun '%s --help' to see a full list of available command line options.\n"),
 			error->message, argv[0]);
 		g_error_free (error);
 		return 1;
@@ -135,7 +135,8 @@ main (int argc, char **argv)
 
         /* now print the files */
         for (p = file_list; p; p = p->next) {
-                g_print ("LABEL FILE = %s\n", (gchar *) p->data);
+                fprintf (stderr, "LABEL FILE = %s\n", (gchar *) p->data);
+
                 label = gl_xml_label_open (p->data, &status);
 
 

--- a/src/glabels-batch.c
+++ b/src/glabels-batch.c
@@ -23,6 +23,7 @@
 #include <glib/gi18n.h>
 
 #include <math.h>
+#include <stdio.h>
 
 #include <libglabels.h>
 #include "merge-init.h"

--- a/src/label-properties-dialog.c
+++ b/src/label-properties-dialog.c
@@ -136,7 +136,7 @@ gl_label_properties_dialog_response_cb (glLabelPropertiesDialog *dialog,
 		gtk_widget_hide (GTK_WIDGET (dialog));
 		break;
 	default:
-		g_print ("response = %d", response);
+		g_error ("response = %d", response);
 		g_assert_not_reached ();
 	}
 

--- a/src/label-text.c
+++ b/src/label-text.c
@@ -27,6 +27,7 @@
 #include <pango/pango.h>
 #include <math.h>
 #include <string.h>
+#include <stdio.h>
 
 #include "font-util.h"
 #include "font-history.h"

--- a/src/label-text.c
+++ b/src/label-text.c
@@ -1059,8 +1059,8 @@ auto_shrink_font_size (cairo_t     *cr,
 
         g_object_unref (layout);
 
-        g_print ("Object w = %g, layout w = %g\n", width, layout_width);
-        g_print ("Object h = %g, layout h = %g\n", height, layout_height);
+        fprintf (stderr, "Object w = %g, layout w = %g\n", width, layout_width);
+        fprintf (stderr, "Object h = %g, layout h = %g\n", height, layout_height);
 
         new_wsize = new_hsize = size;
         if ( layout_width > width )

--- a/src/media-select.c
+++ b/src/media-select.c
@@ -782,7 +782,7 @@ gl_media_select_get_name (glMediaSelect *this)
         }
         else
         {
-                g_print ("notebook page = %d\n", page_num);
+                g_error ("notebook page = %d\n", page_num);
                 g_assert_not_reached ();
         }
 

--- a/src/merge-properties-dialog.c
+++ b/src/merge-properties-dialog.c
@@ -515,7 +515,7 @@ response_cb (glMergePropertiesDialog *dialog,
 	case GTK_RESPONSE_DELETE_EVENT:
 		break;
 	default:
-		g_print ("response = %d", response);
+		g_error ("response = %d", response);
 		g_assert_not_reached ();
 	}
 

--- a/src/prefs-dialog.c
+++ b/src/prefs-dialog.c
@@ -268,7 +268,7 @@ response_cb (glPrefsDialog *dialog,
 	case GTK_RESPONSE_DELETE_EVENT:
 		break;
 	default:
-		g_print ("response = %d", response);
+		g_error ("response = %d", response);
 		g_assert_not_reached ();
 	}
 

--- a/src/text-node.c
+++ b/src/text-node.c
@@ -356,7 +356,7 @@ gl_text_node_lines_print (GList * lines )
 		for (p_node = (GList *) p_line->data, i_node=0; p_node != NULL;
 		     p_node = p_node->next, i_node++) {
 			text_node = (glTextNode *) p_node->data;
-			g_print( "LINE[%d], NODE[%d] = { %d, \"%s\" }\n",
+			fprintf (stderr,  "LINE[%d], NODE[%d] = { %d, \"%s\" }\n",
 				 i_line, i_node,
 				 text_node->field_flag, text_node->data );
 

--- a/src/text-node.c
+++ b/src/text-node.c
@@ -23,6 +23,7 @@
 #include "text-node.h"
 
 #include <string.h>
+#include <stdio.h>
 
 #include "merge.h"
 

--- a/src/view.c
+++ b/src/view.c
@@ -2154,7 +2154,7 @@ resize_event (glView   *view,
 		break;
 
         default:
-                g_warn ("Invalid handle.\n");  /* Should not happen! */
+                g_warning ("Invalid handle.\n");  /* Should not happen! */
 
         }
 
@@ -2198,7 +2198,7 @@ resize_event (glView   *view,
                         break;
 
                 default:
-                        g_warn ("Invalid handle.\n");  /* Should not happen! */
+                        g_warning ("Invalid handle.\n");  /* Should not happen! */
                 }
         }
         else

--- a/src/view.c
+++ b/src/view.c
@@ -2154,7 +2154,7 @@ resize_event (glView   *view,
 		break;
 
         default:
-                g_print ("Invalid handle.\n");  /* Should not happen! */
+                g_warn ("Invalid handle.\n");  /* Should not happen! */
 
         }
 
@@ -2198,7 +2198,7 @@ resize_event (glView   *view,
                         break;
 
                 default:
-                        g_print ("Invalid handle.\n");  /* Should not happen! */
+                        g_warn ("Invalid handle.\n");  /* Should not happen! */
                 }
         }
         else


### PR DESCRIPTION
This is the wrong fix. Everything using going to standard out that I found in my testing used g_print. the right fix would be to point g_print to stderr, Ces la ve. When  I was able to quickly tell that g_print was used for error messages (right before asserts) or similar I used g_debug, g_warning or g_error. Usage message for the gui was left (won't interfere with batch mode, may do the right thing when not started from a terminal), Usage message for batch was changed to fprintf stderr (this will give expected results in a pipe). everything else was changed to fprintf stderr. This last group probably should be audited one of these days.

Fixes #49.