### PR TITLE
glabels: fix build failure on gcc-10 (-fno-common)

### DIFF
--- a/src/font-history.h
+++ b/src/font-history.h
@@ -28,7 +28,7 @@
 G_BEGIN_DECLS
 
 
-glFontHistoryModel *gl_font_history;
+extern glFontHistoryModel *gl_font_history;
 
 
 void            gl_font_history_init (void);

--- a/src/template-history.h
+++ b/src/template-history.h
@@ -28,7 +28,7 @@
 G_BEGIN_DECLS
 
 
-glTemplateHistoryModel *gl_template_history;
+extern glTemplateHistoryModel *gl_template_history;
 
 
 void            gl_template_history_init (void);


### PR DESCRIPTION
gcc-10 changed the default from -fcommon to fno-common:
  https://gcc.gnu.org/PR85678

As a result build fails as:

    ld: label.o:src/template-history.h:31: multiple definition of `gl_template_history'; glabels-batch.o:src/template-history.h:31: first defined here
    ld: label-text.o:src/font-history.h:31: multiple definition of `gl_font_history'; glabels-batch.o:src/font-history.h:31: first defined here
    ld: font-history.o:src/font-history.h:31: multiple definition of `gl_font_history'; glabels-batch.o:src/font-history.h:31: first defined here
    ld: template-history.o:src/template-history.h:31: multiple definition of `gl_template_history'; glabels-batch.o:src/template-history.h:31: first defined here

The change drops redundant definitions in headers and relies on
definitions in .c files.